### PR TITLE
Tweak units rendering order

### DIFF
--- a/TowerNinja/Assets/Prefabs/BigEnemy.prefab
+++ b/TowerNinja/Assets/Prefabs/BigEnemy.prefab
@@ -317,7 +317,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: c49dbd66947a7f747903169c1ba66513, type: 3}
   m_Color: {r: 0.627451, g: 0.39215687, b: 0.39215687, a: 1}
   m_FlipX: 0

--- a/TowerNinja/Assets/Prefabs/BigFriend.prefab
+++ b/TowerNinja/Assets/Prefabs/BigFriend.prefab
@@ -351,7 +351,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 118616867455a404682704905a12e741, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/TowerNinja/Assets/Prefabs/Enemy.prefab
+++ b/TowerNinja/Assets/Prefabs/Enemy.prefab
@@ -426,7 +426,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_Sprite: {fileID: 21300000, guid: 8af66b1975949d04a8c32e3948ea268d, type: 3}
   m_Color: {r: 0.627451, g: 0.39215687, b: 0.39215687, a: 1}
   m_FlipX: 0

--- a/TowerNinja/Assets/Prefabs/EnemySlinger.prefab
+++ b/TowerNinja/Assets/Prefabs/EnemySlinger.prefab
@@ -72,7 +72,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 2
   m_Sprite: {fileID: 21300000, guid: 8307adeb72b552d43ae4741a8124064b, type: 3}
   m_Color: {r: 0.627451, g: 0.39215687, b: 0.39215687, a: 1}
   m_FlipX: 0

--- a/TowerNinja/Assets/Prefabs/Friend.prefab
+++ b/TowerNinja/Assets/Prefabs/Friend.prefab
@@ -316,7 +316,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: c69991f249f406e4fa29d3b69a0a9c5f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/TowerNinja/Assets/Prefabs/FriendSlinger.prefab
+++ b/TowerNinja/Assets/Prefabs/FriendSlinger.prefab
@@ -316,7 +316,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_Sprite: {fileID: 21300000, guid: 2bcc2daa72649124ab3967d8ac233ba1, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0


### PR DESCRIPTION
- smaller units are always rendered later than bigger units
- smaller units show up closer to the camera